### PR TITLE
Allow for proguard to run when building debug flavor of the app.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 /.idea/modules.xml
 /.idea/workspace.xml
 .DS_Store
-/build
+build
 /captures
 .externalNativeBuild
 /gradle.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,12 +27,18 @@ android {
         versionName "1.0-alpha01"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+
     buildTypes {
-        release {
-            debuggable false
+
+        all {
+            // Proguard configs
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+
+        release {
+            debuggable false
             signingConfig signingConfigs.release
         }
     }


### PR DESCRIPTION
This is a quick fix for #7 Make Proguard work. The issue appears to be that when adding `minifyEnabled true` and `shrinkResources true` to the debug config, Proguard was being used but you weren't telling it to use the rules file. Since you want this to be ran in both debug and release, I added it to the `all` buildType.

I do want to note, most people do not add proguard configs to their debug variants due to increasing the build time. This isn't so much of a problem right now with the size of the app but on much larger projects, this can add significant time to the build process.