### PR TITLE
Fix issues in diff_visual_fragment.xml

### DIFF
--- a/app/src/main/res/layout/diff_visual_fragment.xml
+++ b/app/src/main/res/layout/diff_visual_fragment.xml
@@ -92,7 +92,8 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="center"
                     android:indeterminate="true"
-                    android:indeterminateTint="@color/md_indigo_A200" />
+                    android:indeterminateTint="@color/md_indigo_A200"
+                    android:indeterminateTintMode="src_in"/>
 
                 <androidx.core.widget.NestedScrollView
                     android:layout_width="match_parent"


### PR DESCRIPTION
Hi, 

I have found there is an issue in `diff_visual_fragment.xml`. You have used the attribute `android:indeterminateTint` in ProgressBar, which can cause incompatibilities in API < 23 if you did not set `android:indeterminateTintMode="src_in"`.

This pull request help you fix this issue. Thanks for your attention.